### PR TITLE
Add optional audience param

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ auth0AuthorizeURL
     "https://my-app/"
     [ "openid", "name", "email" ]
     (Just "google-oauth2")
+    Nothing
 ```

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "kkpoon/elm-auth0",
     "summary": "Auth0 data types and helper functions",
     "license": "BSD-3-Clause",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "exposed-modules": [
         "Auth0"
     ],

--- a/src/Auth0.elm
+++ b/src/Auth0.elm
@@ -186,13 +186,18 @@ auth0AuthorizeURL :
     -> String
     -> List String
     -> Maybe String
+    -> Maybe String
     -> String
-auth0AuthorizeURL auth0Config responseType redirectURL scopes maybeConn =
+auth0AuthorizeURL auth0Config responseType redirectURL scopes maybeConn maybeAud =
     let
         connectionParam =
             maybeConn
                 |> Maybe.map (\c -> "&connection=" ++ c)
                 |> Maybe.withDefault ""
+        audParam =
+          maybeAud
+            |> Maybe.map (\aud -> "&audience=" ++ aud)
+            |> Maybe.withDefault ""
 
         scopeParam =
             scopes |> String.join " " |> Url.percentEncode
@@ -202,6 +207,7 @@ auth0AuthorizeURL auth0Config responseType redirectURL scopes maybeConn =
             ++ ("?response_type=" ++ responseType)
             ++ ("&client_id=" ++ auth0Config.clientId)
             ++ connectionParam
+            ++ audParam
             ++ ("&redirect_uri=" ++ redirectURL)
             ++ ("&scope=" ++ scopeParam)
 

--- a/src/Auth0.elm
+++ b/src/Auth0.elm
@@ -168,6 +168,7 @@ oAuth2IdentityDecoder =
         -> String -- redirectURL
         -> List String -- scopes
         -> Maybe String -- connection
+        -> Maybe String -- audience
         -> String
 
 e.g.
@@ -178,6 +179,7 @@ e.g.
         "https://my-app/"
         [ "openid", "name", "email" ]
         (Just "google-oauth2")
+        Nothing
 
 -}
 auth0AuthorizeURL :


### PR DESCRIPTION
Fixes #3 

Adds an optional `audience` parameter to the query.

This is useful for providers who might require this; namely auth0.

- Updated docs
- Updated example