### PR TITLE
Try to make the profile request work!

### DIFF
--- a/src/Auth0.elm
+++ b/src/Auth0.elm
@@ -216,11 +216,11 @@ getAuthedUserProfile :
 getAuthedUserProfile auth0Endpoint idToken pDecoder =
     Http.request
         { method = "POST"
-        , headers = []
-        , url = auth0Endpoint ++ "/tokeninfo"
+        , headers = [ Http.header "content-type" "application/json" ]
+        , url = auth0Endpoint ++ "/userinfo"
         , body =
             Http.jsonBody <|
-                Encode.object [ ( "id_token", Encode.string idToken ) ]
+                Encode.object [ ( "access_token", Encode.string idToken ) ]
         , expect = Http.expectJson GotProfile pDecoder
         , timeout = Nothing
         , tracker = Nothing


### PR DESCRIPTION
It's working with `curl`, but I'm still getting a `401` Not Authorized. This could be due to my current process of ...

- `login -> get access_token`
- stop/start `elm-reactor` again ... **

**After adding the new access token to `getAuthedUserProfile` call.

I've not tried a profile call within the same `elm-reactor` run. Generating the `access_token` with Elm app and then running this command:

```curl
curl --request POST \
  --url https://YOUR-AUTH0-URL.auth0.com/userinfo \
  --header 'content-type: application/json' \
  --data '{"access_token": "access_key"}'
```

Should return: `{"sub":"google-oauth2|10277917...","email":"useremail@gmail.com","email_verified":true`